### PR TITLE
Added Force Append Modules option

### DIFF
--- a/autocpenv.param
+++ b/autocpenv.param
@@ -29,6 +29,16 @@ Required=False
 Default=
 Description=Mapping of deadline plugins to cpenv environments. Each line should start with a deadline plugin and end with a space separate list of cpenv environment paths.
 
+[forced_plugin_mapping]
+Type=multilinestring
+Category=Options
+CategoryOrder=0
+Index=4
+Label=Forced Plugin Mapping
+Required=False
+Default=
+Description=Forced mapping of deadline plugins to cpenv environments. These plugins will be appended to whatever mapping is already applied to the job. Each line should start with a deadline plugin and end with a space separate list of cpenv environment paths.
+
 [ShotgunRepo_enable]
 Type=boolean
 Category=Repos

--- a/autocpenv.py
+++ b/autocpenv.py
@@ -304,7 +304,7 @@ def GlobalJobPreLoad(plugin):
     requirements = job.GetJobExtraInfoKeyValue('cpenv_requirements')
     if not requirements:
         plugin.LogInfo('Job has no cpenv requirements...')
-        #return
+        return
 
     # Read config from autocpenv EventPlugin
     configure_autocpenv(plugin.LogInfo)

--- a/autocpenv.py
+++ b/autocpenv.py
@@ -83,9 +83,12 @@ class AutoCpenv(DeadlineEventListener):
         )
 
         forced_requirements = self.resolve_from_job_plugin(self.GetConfigEntry('forced_plugin_mapping'), job_plugin)
-        self.log("Forced requirements (these will be appended to the job requirements):")
-        self.log(" ".join(forced_requirements))
-        requirements.extend(forced_requirements)
+        if forced_requirements:
+            self.log("Forced requirements (these will be appended to the job requirements):")
+            self.log(" ".join(forced_requirements))
+            requirements.extend(forced_requirements)
+        else:
+            self.log("No forced requirements found in the Forced Plugin Mapping settings...")
 
         if not requirements:
             self.log('Error! Failed 4 attempts to find requirements...')
@@ -161,14 +164,14 @@ class AutoCpenv(DeadlineEventListener):
         except cpenv.ResolveError:
             pass
 
-    def resolve_from_job_plugin(self, plugin_setting, job_plugin):
+    def resolve_from_job_plugin(self, plugin_mapping, job_plugin):
         '''Attempt to resolve modules using the Autocpenv event plugins
         configured plugin mapping.
         '''
 
-        self.log('Checking job {} for module requirements...'.format(plugin_setting))
+        self.log('Checking job {} for module requirements...'.format(plugin_mapping))
 
-        plugin_mapping = plugin_mapping_to_dict(plugin_setting)
+        plugin_mapping = plugin_mapping_to_dict(plugin_mapping)
         requirements = plugin_mapping.get(job_plugin, None)
         return requirements
 

--- a/autocpenv.py
+++ b/autocpenv.py
@@ -82,6 +82,11 @@ class AutoCpenv(DeadlineEventListener):
             (self.resolve_from_job_plugin, (plugin_mapping, job_plugin)),
         )
 
+        forced_requirements = self.resolve_from_job_plugin(self.GetConfigEntry('forced_plugin_mapping'), job_plugin)
+        self.log("Forced requirements (these will be appended to the job requirements):")
+        self.log(" ".join(forced_requirements))
+        requirements.extend(forced_requirements)
+
         if not requirements:
             self.log('Error! Failed 4 attempts to find requirements...')
             return
@@ -156,14 +161,14 @@ class AutoCpenv(DeadlineEventListener):
         except cpenv.ResolveError:
             pass
 
-    def resolve_from_job_plugin(self, plugin_mapping, job_plugin):
+    def resolve_from_job_plugin(self, plugin_setting, job_plugin):
         '''Attempt to resolve modules using the Autocpenv event plugins
         configured plugin mapping.
         '''
 
-        self.log('Checking job plugin_mapping for module requirements...')
+        self.log('Checking job {} for module requirements...'.format(plugin_setting))
 
-        plugin_mapping = plugin_mapping_to_dict(plugin_mapping)
+        plugin_mapping = plugin_mapping_to_dict(plugin_setting)
         requirements = plugin_mapping.get(job_plugin, None)
         return requirements
 

--- a/autocpenv.py
+++ b/autocpenv.py
@@ -81,23 +81,34 @@ class AutoCpenv(DeadlineEventListener):
             (self.resolve_from_job_scenefile, (job,)),
             (self.resolve_from_job_plugin, (plugin_mapping, job_plugin)),
         )
-
-        forced_requirements = self.resolve_from_job_plugin(self.GetConfigEntry('forced_plugin_mapping'), job_plugin)
-        if forced_requirements:
-            self.log("Forced requirements (these will be appended to the job requirements):")
-            self.log(" ".join(forced_requirements))
-            requirements.extend(forced_requirements)
-        else:
-            self.log("No forced requirements found in the Forced Plugin Mapping settings...")
-
         if not requirements:
-            self.log('Error! Failed 4 attempts to find requirements...')
-            return
+            self.log('Did not find any job requirements...')
+
+        self.log('Attempting to find forced requirements...')
+        forced_requirements = self.resolve_from_forced_plugin_mappings(job_plugin)
+        if not forced_requirements:
+            self.log('Did not find any forced requirements...')
+
+        # if we have both requirements and forced requirements we merge the lists together and remove duplicates
+        if forced_requirements and requirements:
+            requirements.extend(forced_requirements)
+            # remove duplicates
+            requirements = list(dict.fromkeys(requirements))
         else:
+            # we don't have requirements, use the forced requirements instead
+            requirements = forced_requirements
+
+        if requirements:
+            # print the merged requirements we found...
             self.log('Found {} requirements...'.format(len(requirements)))
             for requirement in requirements:
                 self.log('  ' + requirement)
+        else:
+            # we dont have any job requirements or forced requirements, do nothing...
+            self.log('Did not find any requirements for this job...')
+            return
 
+        # set the job cpenv requirements on the jobExtraInfo key
         self.log('Setting JobExtranInfo cpenv_requirements')
         job.SetJobExtraInfoKeyValue(
             'cpenv_requirements',
@@ -170,10 +181,23 @@ class AutoCpenv(DeadlineEventListener):
         '''
 
         self.log('Checking job {} for module requirements...'.format(plugin_mapping))
-
+        if not plugin_mapping:
+            self.log('Job plugin has no module requirements...')
+            return None
         plugin_mapping = plugin_mapping_to_dict(plugin_mapping)
         requirements = plugin_mapping.get(job_plugin, None)
         return requirements
+
+    def resolve_from_forced_plugin_mappings(self, job_plugin):
+        '''Attempt to resolve modules from the autocpenv forced plugin mappings setting'''
+        forced_requirements = self.resolve_from_job_plugin(self.GetConfigEntry('forced_plugin_mapping'), job_plugin)
+        if forced_requirements:
+            self.log("Forced requirements (these will be appended to the job requirements):")
+            self.log(" ".join(forced_requirements))
+            return forced_requirements
+        else:
+            self.log("No forced requirements found in the Forced Plugin Mapping settings...")
+            return None
 
 
 class EventLogReporter(cpenv.Reporter):
@@ -280,7 +304,7 @@ def GlobalJobPreLoad(plugin):
     requirements = job.GetJobExtraInfoKeyValue('cpenv_requirements')
     if not requirements:
         plugin.LogInfo('Job has no cpenv requirements...')
-        return
+        #return
 
     # Read config from autocpenv EventPlugin
     configure_autocpenv(plugin.LogInfo)


### PR DESCRIPTION
Added a new option to define forced plugins that should be appended to the job even if the job has it's own modules. 

The cpenv modules defined for the Plugins in this option box will always be merged with the Job's or Machine's CPENV environment.

This allows for configuring the renderfarm with packages that only it should load, for example a bootstrap package/nuke init.py file for ShotGrid.